### PR TITLE
GitHub release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,3 +35,7 @@ pluginBundle {
         }
     }
 }
+
+dependencies {
+    compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.6.0'
+}

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -257,4 +257,8 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
         "publishGroovydocs" | _
         "publish"           | _
     }
+
+    def "task :#taskToRun will publish a release to github"() {
+
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -92,6 +92,7 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
         "check"               | "releaseCheck"
         "assemble"            | "release"
         "publishPlugins"      | "final"
+        "publishPlugins"      | "candidate"
         "publishToMavenLocal" | "snapshot"
     }
 

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -46,6 +46,9 @@ import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.gradle.testing.jacoco.tasks.JacocoReportsContainer
 import org.kt3k.gradle.plugin.CoverallsPlugin
+import wooga.gradle.github.GithubPlugin
+import wooga.gradle.github.publish.GithubPublish
+import wooga.gradle.github.publish.GithubPublishPlugin
 
 /**
  * This plugin is a convenient gradle plugin which which acts as a base for all atlas gradle plugins
@@ -80,6 +83,7 @@ class PluginsPlugin implements Plugin<Project> {
             apply(ReleasePlugin)
             apply(JacocoPlugin)
             apply(CoverallsPlugin)
+            apply(GithubPlugin)
             apply(MavenPublishPlugin)
         }
 
@@ -173,6 +177,14 @@ class PluginsPlugin implements Plugin<Project> {
         publishTask.mustRunAfter releaseTask
 
         Configuration archives = project.configurations.maybeCreate('archives')
+
+        GithubPublish githubPublishTask = (GithubPublish) tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME)
+        githubPublishTask.onlyIf(new ProjectStatusTaskSpec('candidate', 'release'))
+        githubPublishTask.from(archives)
+        githubPublishTask.dependsOn archives
+        githubPublishTask.tagName = "v${project.version}"
+        githubPublishTask.setReleaseName(project.version.toString())
+        githubPublishTask.setPrerelease({ project.status != 'release' })
     }
 
     private static configureCoverallsTask(final Project project) {

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -152,6 +152,7 @@ class PluginsPlugin implements Plugin<Project> {
         Task postReleaseTask = rootTasks.getByName(ReleasePlugin.POST_RELEASE_TASK_NAME)
         Task snapshotTask = rootTasks.getByName(ReleasePlugin.SNAPSHOT_TASK_NAME)
         Task finalTask = rootTasks.getByName(ReleasePlugin.FINAL_TASK_NAME)
+        Task candidateTask = rootTasks.getByName(ReleasePlugin.CANDIDATE_TASK_NAME)
         Task releaseTask = rootTasks.getByName("release")
         Task publishPluginsTask = tasks.getByName("publishPlugins")
         Task publishToLocalMavenTask = tasks.getByName(MavenPublishPlugin.PUBLISH_LOCAL_LIFECYCLE_TASK_NAME)
@@ -162,6 +163,7 @@ class PluginsPlugin implements Plugin<Project> {
         releaseCheckTask.dependsOn checkTask
         releaseTask.dependsOn assembleTask
         finalTask.dependsOn publishPluginsTask
+        candidateTask.dependsOn publishPluginsTask
         snapshotTask.dependsOn publishToLocalMavenTask
 
         publishToLocalMavenTask.mustRunAfter postReleaseTask

--- a/src/main/groovy/wooga/gradle/plugins/ProjectStatusTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/ProjectStatusTaskSpec.groovy
@@ -1,0 +1,47 @@
+package wooga.gradle.plugins
+
+import org.gradle.api.Task
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.specs.Spec
+
+/**
+ * A generic <code>Spec&lt;Task&gt;</code> object which can be used to set task execution <code>onlyIf</code>
+ * property when <code>project.status</code> equals one of the <code>validStatusValues</code> provided.
+ */
+class ProjectStatusTaskSpec implements Spec<Task> {
+
+    private static final Logger logger = Logging.getLogger(ProjectStatusTaskSpec)
+
+    private final List<Object> validStatusValues = new ArrayList<>()
+
+    /**
+     * Creates a new <code>ProjectStatusTaskSpec</code> object with given <code>validStatusValues</code>
+     * @param validStatusValues <code>List&lt;Object&gt;</code> with valid status values to check
+     */
+    ProjectStatusTaskSpec(List<Object> validStatusValues) {
+        this.validStatusValues.addAll(validStatusValues)
+    }
+
+    /**
+     * Creates a new <code>ProjectStatusTaskSpec</code> object with given <code>validStatusValues</code>
+     * @param validStatusValues one or more valid status value to check
+     */
+    ProjectStatusTaskSpec(Object... validStatusValues) {
+        this.validStatusValues.addAll(validStatusValues)
+    }
+
+    /**
+     * Checks if task execution is satisfied. Check current <code>project.status</code> property and checks if the value
+     * is equal to one of <code>validStatusValues</code> provided.
+     * @param task the task to check if execution is valid
+     * @return boolean if <code>project.status</code> is equal to one of <code>validStatusValues</code> provided.
+     */
+
+    @Override
+    boolean isSatisfiedBy(Task task) {
+        Boolean satisfied = validStatusValues.contains(task.project.status)
+        logger.info("'project.status' check satisfied $satisfied")
+        return satisfied
+    }
+}

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -32,6 +32,8 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.kt3k.gradle.plugin.CoverallsPlugin
 import spock.lang.Unroll
+import wooga.gradle.github.GithubPlugin
+import wooga.gradle.github.publish.GithubPublish
 
 class PluginsPluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.plugins'
@@ -57,14 +59,15 @@ class PluginsPluginSpec extends ProjectSpec {
         project.plugins.hasPlugin(pluginType)
 
         where:
-        pluginName       | pluginType
-        "groovy"         | GroovyPlugin
-        "idea"           | IdeaPlugin
-        "maven-publish"  | MavenPublishPlugin
-        "plugin-publish" | PublishPlugin
-        "nebula.release" | ReleasePlugin
-        "jacoco"         | JacocoPlugin
-        "coveralls"      | CoverallsPlugin
+        pluginName         | pluginType
+        "groovy"           | GroovyPlugin
+        "idea"             | IdeaPlugin
+        "maven-publish"    | MavenPublishPlugin
+        "plugin-publish"   | PublishPlugin
+        "nebula.release"   | ReleasePlugin
+        "jacoco"           | JacocoPlugin
+        "coveralls"        | CoverallsPlugin
+        "net.wooga.github" | GithubPlugin
     }
 
     @Unroll("creates the task #taskName")


### PR DESCRIPTION
## Description

Add github release support by applying `net.wooga.github` plugin. This allows plugins to create github releases when issuing `final` or `rc` releases.

## Changes

![ADD] `net.wooga.github` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
