### PR TITLE
Fix missing rc task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -300,4 +300,18 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
         "publishGroovydocs" | _
         "publish"           | _
     }
+
+    @Unroll
+    def "task :#taskAlias will execute :#taskToRun"() {
+        when:
+        def result = runTasks(taskAlias, "--dry-run")
+
+        then:
+        result.standardOutput.contains(":${taskToRun}")
+        !result.standardOutput.contains(":${taskAlias}")
+
+        where:
+        taskAlias | taskToRun
+        "rc"      | "candidate"
+    }
 }


### PR DESCRIPTION
## Description

With the new `Jenkins` file update from #7 we have the option to build `candidate` builds.
The `rc` task requested by the `Jenkinsfile` was missing and this patch implements it.

resolves #8

## Changes

![FIX] missing `rc` task for CI system

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
