### PR TITLE
Update nebular-test to use fixed version 7.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '1.2.0'
+    id 'net.wooga.plugins' version '1.3.0'
 }
 
 group 'net.wooga.gradle'
@@ -45,4 +45,8 @@ dependencies {
     compile 'com.netflix.nebula:nebula-release-plugin:7.+'
     compile 'com.gradle.publish:plugin-publish-plugin:0.10.0'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+
+    testCompile('com.netflix.nebula:nebula-test:7.7.0') {
+        force = true
+    }
 }

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -114,7 +114,7 @@ class PluginsPlugin implements Plugin<Project> {
                 exclude module: 'groovy-all'
             }
 
-            testCompile 'com.netflix.nebula:nebula-test:latest.release'
+            testCompile 'com.netflix.nebula:nebula-test:7.7.0'
             testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 
             compile 'commons-io:commons-io:2.5'


### PR DESCRIPTION
## Description

The gradle test plugin `nebular-test` introduced some breaking changes and will continue to do so because nebular is mainly supporting gradle 5 and 6. This patch just sets the version to `7.7.0` so downstream projects won't break without changes.

## Changes

* ![UPDATE] `nebular-test` to `7.7.0`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
