### PR TITLE
Update com.gradle.plugin-publish to 0.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'net.wooga.plugins' version '1.3.0'
+    id 'com.gradle.plugin-publish' version '0.11.0'
 }
 
 group 'net.wooga.gradle'
@@ -43,7 +44,7 @@ github {
 dependencies {
     compile 'gradle.plugin.net.wooga.gradle:atlas-github:1.+'
     compile 'com.netflix.nebula:nebula-release-plugin:7.+'
-    compile 'com.gradle.publish:plugin-publish-plugin:0.10.0'
+    compile 'com.gradle.publish:plugin-publish-plugin:0.11.0'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 
     testCompile('com.netflix.nebula:nebula-test:7.7.0') {


### PR DESCRIPTION
## Description

Due to a security issue with the old versions of the `com.gradle.plugin-publish` plugin, all version < `0.11.0` won't function anymore. We need to update to the latest version to be able to publish plugins. Because this plugin uses itself to publish, I needed to add the plugin with the newer version directly.

## Changes

* ![UPDATE] `com.gradle.plugin-publish` to `0.11.0`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
