### PR TITLE
Updated build.gradle plugins plugin version to 2.1.1-rc.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
 plugins {
-    id 'net.wooga.plugins' version '2.0.0'
+    id 'net.wooga.plugins' version '2.1.1-rc.1'
 }
 
 group 'net.wooga.gradle'

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -53,8 +53,6 @@ import wooga.gradle.githubReleaseNotes.GithubReleaseNotesPlugin
 import wooga.gradle.githubReleaseNotes.tasks.GenerateReleaseNotes
 import wooga.gradle.plugins.releasenotes.ReleaseNotesStrategy
 
-//import wooga.gradle.githubReleaseNotes.GithubReleaseNotesPlugin
-
 import java.util.concurrent.Callable
 
 /**


### PR DESCRIPTION
## Description
Updated the plugins plugin version in this project build.gradle file to 2.1.1-rc.1, which provides support to built-in release notes.

## Changes
* ![UPDATE] `net.wooga.plugins` in `build.gradle` to 2.1.1-rc.1


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
