### PR TITLE
Sonar integration and fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@
 withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
                  usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
                  usernamePassword(credentialsId: 'github_integration_3', passwordVariable: 'githubPassword3', usernameVariable: 'githubUser3'),
-                 string(credentialsId: 'atlas_plugins_coveralls_token', variable: 'coveralls_token')]) {
+                 string(credentialsId: 'atlas_plugins_coveralls_token', variable: 'coveralls_token'),
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
     def testEnvironment = [
         'osx':
         [
@@ -40,5 +41,5 @@ withCredentials([usernamePassword(credentialsId: 'github_integration', passwordV
     ]
 
 
-    buildGradlePlugin plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildGradlePlugin plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment: testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 }
 
 plugins {
-    id 'net.wooga.plugins' version '2.1.1-rc.1'
+    id 'net.wooga.plugins' version '2.2.0-rc.2'
 }
 
 group 'net.wooga.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,24 @@
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-github:2.+'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.14.0'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3)'
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[0.1, 0.2)'
+        classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:0.1.0-rc.8'
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
     }
 }
 
-plugins {
-    id 'net.wooga.plugins' version '2.2.0-rc.2'
-}
+apply plugin: new GroovyScriptEngine(
+        [file('src/main/groovy').absolutePath,
+         file('src/main/resources').absolutePath].toArray(new String[2]),
+        this.class.classLoader
+).loadScriptByName('wooga/gradle/plugins/PluginsPlugin.groovy')
 
 group 'net.wooga.gradle'
 description = 'Plugin for wooga gradle plugin development.'

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -52,8 +52,6 @@ import wooga.gradle.github.publish.tasks.GithubPublish
 import wooga.gradle.githubReleaseNotes.GithubReleaseNotesPlugin
 import wooga.gradle.githubReleaseNotes.tasks.GenerateReleaseNotes
 import wooga.gradle.plugins.releasenotes.ReleaseNotesStrategy
-import wooga.gradle.plugins.sonarqube.PropertyFactory
-import wooga.gradle.plugins.sonarqube.PropertyFactories
 import wooga.gradle.plugins.sonarqube.RepositoryInfo
 import wooga.gradle.plugins.sonarqube.SonarQubeConfiguration
 import wooga.gradle.version.VersionCodeScheme

--- a/src/main/groovy/wooga/gradle/plugins/sonarqube/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/sonarqube/SonarQubeConfiguration.groovy
@@ -31,16 +31,17 @@ class SonarQubeConfiguration {
     Action<? extends SonarQubeProperties> generateSonarProperties(RepositoryInfo repoInfo, JavaPluginConvention javaConvention) {
         return {sonarProps ->
             sonarProps.with {
+                property "sonar.login",
+                        propertyFactory.create("sonar.login", "SONAR_LOGIN", null)
+                property "sonar.host.url",
+                        propertyFactory.create("sonar.host.url", "SONAR_HOST", null)
                 property "sonar.projectName",
                         propertyFactory.create("sonar.projectName", "SONAR_PROJECT_NAME",
                                 repoInfo.repositoryName)
                 property "sonar.projectKey",
                         propertyFactory.create("sonar.projectKey", "SONAR_PROJECT_KEY",
                                 defaultProjectName(repoInfo))
-                property "sonar.login",
-                        propertyFactory.create("sonar.login", "SONAR_LOGIN", "")
-                property "sonar.host.url",
-                        propertyFactory.create("sonar.host.url", "SONAR_HOST", "")
+                //plugin default is sourceSets.main.allJava.srcDirs (with only existing dirs)
                 property "sonar.sources",
                         propertyFactory.create("sonar.sources", "SONAR_SOURCES",
                                 srcDirMatching(javaConvention){ !it.name.toLowerCase().contains("test") }.join(","))
@@ -57,7 +58,7 @@ class SonarQubeConfiguration {
     private static List<String> srcDirMatching(JavaPluginConvention javaConvention, Closure closure) {
         return javaConvention.sourceSets.findAll(closure).
                 collect { SourceSet sourceSet ->
-                    sourceSet.allJava.sourceDirectories.collect {it.absolutePath}
+                    sourceSet.allJava.sourceDirectories.findAll{it.exists()}.collect{it.absolutePath}
                 }.flatten() as List<String>
     }
 }

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -229,8 +229,8 @@ class PluginsPluginSpec extends ProjectSpec {
         SonarQubeTask sonarTask = project.tasks.getByName(SonarQubeExtension.SONARQUBE_TASK_NAME)
         def properties = sonarTask.getProperties()
 
+        //sonar.host.url is not here as CI always will have SONAR_HOST set, so it is never null there.
         properties["sonar.login"] == null
-        properties["sonar.host.url"] == null
         properties["sonar.projectKey"] == "${ghCompany}_${ghRepoName}"
         properties["sonar.projectName"] == ghRepoName
         properties["sonar.sources"] == srcFolder.absolutePath


### PR DESCRIPTION
## Description
Put sonarqube integration into the project, passing the `sonarToken` secret to the build script in `Jenkinsfile`.  This shown a issue with the sonar integration, as the `sonarqube` gradle task would fail trying to search non-existing directories, this was fixed, now only existing directories are passed to the `sonarqube` sources/tests parameters. 

Furthermore, the project now is loading itself as a plugin (as opposed to using a fixed `wooga.plugins` version from the plugins repository) which allows for more immediate feedback on changes.


## Changes
* ![ADD] SonarQube integration of the plugin source code
* ![FIX] SonarQube plugin now only searches existing directories
* ![CHANGE] Project now loads itself as plugin in its `build.gradle` file.


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
