### PR TITLE
Fix: release status for github publish task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -122,6 +122,29 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
+    def "task :#lifecycleTask #skip in stage #releaseStage"() {
+        given: "some dummy test"
+        writeTest('src/integrationTest/java/', "wooga.integration", false)
+        writeTest('src/test/java/', "wooga.test", false)
+
+        when:
+        def result = runTasks(lifecycleTask ,"-Prelease.stage=${releaseStage}")
+
+        then:
+        if(skip=="skip") {
+            result.standardOutput.contains("${lifecycleTask} SKIPPED")
+        } else {
+            !result.wasSkipped(lifecycleTask)
+        }
+
+        where:
+        lifecycleTask    | releaseStage | skip
+        ":githubPublish" | "final"      | "don't skip"
+        ":githubPublish" | "rc"         | "don't skip"
+        ":githubPublish" | "not-finalrc"| "skip"
+    }
+
+    @Unroll
     def "verify :#taskAfter runs after :#task when execute '#execute'"() {
         given: "some dummy test"
         writeTest('src/integrationTest/java/', "wooga.integration", false)

--- a/src/main/groovy/wooga/gradle/plugins/ProjectStatusTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/ProjectStatusTaskSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Task
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.specs.Spec
+import wooga.gradle.version.VersionPluginExtension
 
 /**
  * A generic <code>Spec&lt;Task&gt;</code> object which can be used to set task execution <code>onlyIf</code>
@@ -56,7 +57,8 @@ class ProjectStatusTaskSpec implements Spec<Task> {
 
     @Override
     boolean isSatisfiedBy(Task task) {
-        Boolean satisfied = validStatusValues.contains(task.project.status)
+        def currentStage = task.project.properties["release.stage"]
+        def satisfied = currentStage in validStatusValues
         logger.info("'project.status' check satisfied $satisfied")
         return satisfied
     }


### PR DESCRIPTION
## Description
Github tags were not being published, due to the `onlyIf` verification for the `:githubPublish` task being associated with elements from the already removed nebula.release plugin. Changed it to reflect the behavior of the atlas-version plugin.


## Changes
* ![FIX] GithubPublish `onlyIf` clause now uses release status compatible with the atlas-version plugin;





[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
