### PR TITLE
Fix: release tags branch and integration tests classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ apply plugin: new GroovyScriptEngine(
 group 'net.wooga.gradle'
 description = 'Plugin for wooga gradle plugin development.'
 
+
 pluginBundle {
     website = 'https://wooga.github.io/atlas-plugins'
     vcsUrl = 'https://github.com/wooga/atlas-plugins'

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -160,6 +160,7 @@ class PluginsPlugin implements Plugin<Project> {
     }
 
     private static void setupDependencies(Project project) {
+        JavaPluginConvention javaConvention = project.getConvention().getPlugins().get("java") as JavaPluginConvention
         DependencyHandler dependencies = project.getDependencies();
         dependencies.add("api", dependencies.gradleApi())
         dependencies.add("testImplementation", 'junit:junit:[4,5)')
@@ -169,6 +170,7 @@ class PluginsPlugin implements Plugin<Project> {
         dependencies.add("testImplementation", 'com.netflix.nebula:nebula-test:[8,9)')
         dependencies.add("testImplementation", 'com.github.stefanbirkner:system-rules:[1,2)')
         dependencies.add("implementation", 'commons-io:commons-io:[2,3)')
+        dependencies.add("integrationTestImplementation", javaConvention.sourceSets.getByName("test").output)
     }
 
     private static def configureGradleDocsTask(final Project project) {
@@ -244,6 +246,7 @@ class PluginsPlugin implements Plugin<Project> {
             githubPublishTask.with {
                 releaseName.set(project.version.toString())
                 tagName.set("v${project.version}")
+                targetCommitish.set(project.extensions.grgit.branch.current.name as String)
                 prerelease.set(project.properties['release.stage']!='final')
                 body.set(releaseNotesTask.output.map{it.asFile.text })
             }

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -39,7 +39,6 @@ import org.sonarqube.gradle.SonarQubePlugin
 import org.sonarqube.gradle.SonarQubeTask
 import spock.lang.Unroll
 import wooga.gradle.github.GithubPlugin
-import wooga.gradle.github.base.GithubPluginExtension
 import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.github.publish.tasks.GithubPublish
 import wooga.gradle.githubReleaseNotes.GithubReleaseNotesPlugin
@@ -289,6 +288,21 @@ class PluginsPluginSpec extends ProjectSpec {
         then: "values should be the ones that has been set"
         versionExt.versionScheme.get() == VersionScheme.staticMarker
         versionExt.versionCodeScheme.get() == VersionCodeScheme.releaseCountBasic
+    }
+
+    def "configures github publish task"() {
+        given: "project with plugins plugin applied"
+        project.plugins.apply(PLUGIN_NAME)
+        project.evaluate()
+
+        when: "evaulating github publish task"
+        def ghPublishTask = project.tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME) as GithubPublish
+
+        then: "github publish task should be configured"
+        ghPublishTask.releaseName.get() == project.version.toString()
+        ghPublishTask.tagName.get() == "v${project.version}"
+        ghPublishTask.targetCommitish.get() == project.extensions.grgit.branch.current.name as String
+        ghPublishTask.prerelease.get() == (project.properties['release.stage']!='final')
     }
 
     def createSrcFile(String folderStr, String filename) {


### PR DESCRIPTION
## Description
Release tags for the github releases are now generated on current branch, instead of always using master HEAD as base.

Previous method of including unit tests classpath into integraiton tests broke with the update to gradle 6.9, so we fixed it using another way to do so.


## Changes
* ![FIX] release tags are now generated on current branch
* ![FIX] unit tests are included in the classpath of integration tests

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
