### PR TITLE
Force groovy modules to version of version shipped with gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,13 +80,3 @@ dependencies {
     testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.1.2'
     testImplementation 'org.ajoberstar.grgit:grgit-core:[4,5)'
 }
-
-configurations.all {
-    resolutionStrategy {
-        force 'org.codehaus.groovy:groovy-all:2.5.12'
-        force 'org.codehaus.groovy:groovy-macro:2.5.12'
-        force 'org.codehaus.groovy:groovy-nio:2.5.12'
-        force 'org.codehaus.groovy:groovy-sql:2.5.12'
-        force 'org.codehaus.groovy:groovy-xml:2.5.12'
-    }
-}

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
@@ -123,6 +125,17 @@ class PluginsPlugin implements Plugin<Project> {
                 }
             }
         }
+
+        project.configurations.all({ Configuration configuration ->
+            configuration.resolutionStrategy({ ResolutionStrategy strategy ->
+                def localGroovy = GroovySystem.getVersion()
+                strategy.force("org.codehaus.groovy:groovy-all:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-macro:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-nio:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-sql:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-xml:${localGroovy}")
+            })
+        })
     }
 
     private static void configureReleaseNotes(Project project) {

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -316,4 +316,25 @@ class PluginsPluginSpec extends ProjectSpec {
             """.stripIndent()
         return folder
     }
+
+    def "will force groovy modules to local groovy version"() {
+        given: "project with plugins plugin applied"
+        project.plugins.apply(PLUGIN_NAME)
+
+        expect:
+        def localGroovy = GroovySystem.getVersion()
+        project.configurations.every {
+            //we turn the list of force modules to string to not test against gradle internals
+            def forcedModules = it.resolutionStrategy.forcedModules.toList().collect { it.toString() }
+            forcedModules.containsAll(
+                    [
+                            "org.codehaus.groovy:groovy-all:${localGroovy}".toString(),
+                            "org.codehaus.groovy:groovy-macro:${localGroovy}".toString(),
+                            "org.codehaus.groovy:groovy-nio:${localGroovy}".toString(),
+                            "org.codehaus.groovy:groovy-sql:${localGroovy}".toString(),
+                            "org.codehaus.groovy:groovy-xml:${localGroovy}".toString()
+                    ]
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Description

We have constant issues with groovy dependencies from different libraries. One way of dealing with this in gradle is to add a force resolution override. That worked well in the last couple of month but has to be done in each project. To make this easier I deciced to pull this into our base plugin for all plugins so we don't need to worry about the version of gradle in use.

I'm still uncertain if this is a good idea though as I feel that we will end up with other error especially when thinking of upgrading to gradle 7 which ships and works with groovy 3 which is in no way compatible to groovy 2.5. This setup I propose here seems to work. It should be easy enough be removed if we see issues with it.

## Changes

* ![IMPROVE] groovy force override to use local groovy version from gradle

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"