### PR TITLE
Changed release target commitish to be HEADs' commit hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 buildscript {
     repositories {
         mavenCentral()
@@ -30,6 +31,7 @@ buildscript {
     }
 }
 
+project.extensions.add("repoName", "wooga/atlas-plugins")
 apply plugin: new GroovyScriptEngine(
         [file('src/main/groovy').absolutePath,
          file('src/main/resources').absolutePath].toArray(new String[2]),
@@ -55,7 +57,7 @@ pluginBundle {
 }
 
 github {
-    repositoryName = "wooga/atlas-plugins"
+    repositoryName = project.extensions."repoName"
 }
 
 compileJava   {

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -195,7 +195,7 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
     //Ignore for now
     @IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
     @Unroll
-    def "task :#taskToRun saves jococo exec binaries to #expectedOutput"() {
+    def "task :#taskToRun saves jacoco exec binaries to #expectedOutput"() {
         given: "some dummy test"
         fork = true
         writeTest('src/integrationTest/java/', "wooga.integration", false)

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -219,7 +219,7 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
 
     @Unroll
     def "task :#taskToRun generates #output_type reports"() {
-        given: "some dummy test"
+        given: "some dummy test "
         fork = true
 
         writeTest('src/integrationTest/java/', "wooga.integration", false)

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -127,6 +127,7 @@ class PluginsPlugin implements Plugin<Project> {
     }
 
     private static void configureReleaseNotes(Project project) {
+        Grgit git = project.extensions.grgit
         def releaseNotesProvider = project.tasks.register(RELEASE_NOTES_TASK_NAME, GenerateReleaseNotes)
         releaseNotesProvider.configure { task ->
             def versionExt = project.extensions.findByType(VersionPluginExtension)
@@ -138,7 +139,7 @@ class PluginsPlugin implements Plugin<Project> {
                         return null
                     }
                 })
-                task.branch.set(project.extensions.grgit.branch.current.name as String)
+                task.to.set(git.head().id)
                 task.output.set(new File("${project.buildDir}/outputs/release-notes.md"))
                 task.strategy.set(new ReleaseNotesStrategy())
             }

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -18,6 +18,7 @@ package wooga.gradle.plugins
 
 import com.gradle.publish.PluginBundleExtension
 import com.gradle.publish.PublishPlugin
+import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.gradle.GrgitPlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
@@ -241,12 +242,13 @@ class PluginsPlugin implements Plugin<Project> {
         def tasks = project.tasks
         def releaseNotesTask = tasks.getByName(RELEASE_NOTES_TASK_NAME) as GenerateReleaseNotes
         def publishTaskProvider = tasks.named(GithubPublishPlugin.PUBLISH_TASK_NAME)
+        Grgit git = project.extensions.grgit
         publishTaskProvider.configure {GithubPublish githubPublishTask ->
             githubPublishTask.onlyIf(new ProjectStatusTaskSpec("rc", "final"))
             githubPublishTask.with {
                 releaseName.set(project.version.toString())
                 tagName.set("v${project.version}")
-                targetCommitish.set(project.extensions.grgit.branch.current.name as String)
+                targetCommitish.set(git.head().id as String)
                 prerelease.set(project.properties['release.stage']!='final')
                 body.set(releaseNotesTask.output.map{it.asFile.text })
             }

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -301,7 +301,7 @@ class PluginsPluginSpec extends ProjectSpec {
         then: "github publish task should be configured"
         ghPublishTask.releaseName.get() == project.version.toString()
         ghPublishTask.tagName.get() == "v${project.version}"
-        ghPublishTask.targetCommitish.get() == project.extensions.grgit.branch.current.name as String
+        ghPublishTask.targetCommitish.get() == project.extensions.grgit.head().id
         ghPublishTask.prerelease.get() == (project.properties['release.stage']!='final')
     }
 


### PR DESCRIPTION
## Description
Changed release target commitish to be HEADs' commit hash, as Jenkins PR branches does not contains any references to a remote branch, so we have to use the commit hash as a way to associate local with remote.

## Changes
* ![CHANGE] GIthub Release target commitish now points to current HEAD commit hash.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
