### PR TITLE
Small fixes for issues #67 and #68

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -122,26 +122,27 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
-    def "task :#lifecycleTask #skip in stage #releaseStage"() {
+    def "task #lifecycleTask #skip in stage #releaseStage"() {
         given: "some dummy test"
         writeTest('src/integrationTest/java/', "wooga.integration", false)
         writeTest('src/test/java/', "wooga.test", false)
 
         when:
-        def result = runTasks(lifecycleTask ,"-Prelease.stage=${releaseStage}")
+         def result = runTasks(lifecycleTask ,"-Prelease.stage=${releaseStage}")
 
         then:
-        if(skip=="skip") {
-            result.standardOutput.contains("${lifecycleTask} SKIPPED")
-        } else {
-            !result.wasSkipped(lifecycleTask)
-        }
+        skip=="skip"?
+                result.standardOutput.contains("${lifecycleTask} SKIPPED") :
+                !result.wasSkipped(lifecycleTask)
 
         where:
         lifecycleTask    | releaseStage | skip
         ":githubPublish" | "final"      | "don't skip"
         ":githubPublish" | "rc"         | "don't skip"
-        ":githubPublish" | "not-finalrc"| "skip"
+        ":githubPublish" | "snapshot"   | "skip"
+        ":releaseNotes"  | "final"      | "don't skip"
+        ":releaseNotes"  | "rc"         | "don't skip"
+        ":releaseNotes"  | "snapshot"   | "skip"
     }
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/PluginsPlugin.groovy
@@ -128,6 +128,7 @@ class PluginsPlugin implements Plugin<Project> {
     private static void configureReleaseNotes(Project project) {
         def releaseNotesProvider = project.tasks.register(RELEASE_NOTES_TASK_NAME, GenerateReleaseNotes)
         releaseNotesProvider.configure { task ->
+            task.onlyIf(new ProjectStatusTaskSpec("rc", "final"))
             def versionExt = project.extensions.findByType(VersionPluginExtension)
             if (versionExt) {
                 task.from.set(versionExt.version.map { version ->
@@ -244,8 +245,8 @@ class PluginsPlugin implements Plugin<Project> {
         publishTaskProvider.configure {GithubPublish githubPublishTask ->
             githubPublishTask.onlyIf(new ProjectStatusTaskSpec("rc", "final"))
             githubPublishTask.with {
-                releaseName.set(project.version.toString())
-                tagName.set("v${project.version}")
+                releaseName.set(project.provider {project.version.toString()})
+                tagName.set(project.provider {"v${project.version}"})
                 targetCommitish.set(project.extensions.grgit.branch.current.name as String)
                 prerelease.set(project.properties['release.stage']!='final')
                 body.set(releaseNotesTask.output.map{it.asFile.text })


### PR DESCRIPTION
## Description
`project.version` new refered in a lazy manner and releaseNotes  task only runs on RC and Release release types.

resolves #68
resolves #67

## Changes
* ![FIX] releaseNotes task only runs now in RCs and Releases
* ![FIX] `project.version` references aren't resolved too early anymore.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
