### PR TITLE
 Set fixed java source compatibility 3.x [ATLAS-465]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,13 @@ buildscript {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3)'
         classpath 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[0.1, 0.2)'
         classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:0.1.0-rc.8'
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:[0.1.1,2)'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
+    }
+    configurations.all {
+        resolutionStrategy {
+            force 'org.ajoberstar.grgit:grgit-core:4.1.1'
+        }
     }
 }
 
@@ -73,18 +78,13 @@ github {
     repositoryName = "wooga/atlas-plugins"
 }
 
-compileJava   {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
-}
-
 dependencies {
     implementation 'gradle.plugin.net.wooga.gradle:atlas-github:2.+'
     implementation 'com.gradle.publish:plugin-publish-plugin:0.14.0'
     implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3)'
     implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[0.1, 0.2)'
     implementation 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:0.1.0-rc.8'
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2)'
     implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
     testImplementation('com.netflix.nebula:nebula-test:[8,9)') {
         version {

--- a/src/main/groovy/wooga/gradle/plugins/LocalPluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/LocalPluginsPlugin.groovy
@@ -1,6 +1,6 @@
 package wooga.gradle.plugins
 
-
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.plugins.PublishingPlugin
@@ -56,6 +57,7 @@ class LocalPluginsPlugin implements Plugin<Project> {
         def integrationTestTask = setupIntegrationTestTask(project, project.tasks)
         Task testTask = project.tasks.getByName(JavaPlugin.TEST_TASK_NAME)
 
+        configureSourceCompatibility(project)
         configureGroovyDocsTask(project)
         configureJacocoTestReport(project, integrationTestTask, testTask)
         configureSonarQubeExtension(project, SonarQubeConfiguration.withEnvVarPropertyFallback(project))
@@ -233,5 +235,10 @@ class LocalPluginsPlugin implements Plugin<Project> {
                 strategy.force("org.codehaus.groovy:groovy-xml:${version}")
             })
         })
+    }
+
+    static void configureSourceCompatibility(Project project) {
+        JavaPluginExtension javaExtension = project.extensions.getByType(JavaPluginExtension)
+        javaExtension.sourceCompatibility = JavaVersion.VERSION_1_8
     }
 }


### PR DESCRIPTION
## Description

This patch sets a fixed value for the java source compatibility value. I set it to `'1.8'`.

## Changes

* ![IMPROVE] fixed java source compatibility to `1.8`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"