### PR TITLE
Fix missing targetCommitish for github publish [ATLAS-579]

### DIFF
--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -296,14 +296,32 @@ class PluginsPluginSpec extends ProjectSpec {
         project.plugins.apply(PLUGIN_NAME)
         project.evaluate()
 
+        and: "switch current branch"
+        getGit().checkout(branch: 'test_branch', createBranch: true, startPoint: getGit().resolve.toRevisionString(getGit().branch.current().fullName))
+
         when: "evaulating github publish task"
         def ghPublishTask = project.tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME) as GithubPublish
 
         then: "github publish task should be configured"
+        ghPublishTask.targetCommitish.get() == 'test_branch'
         ghPublishTask.releaseName.get() == project.version.toString()
         ghPublishTask.tagName.get() == "v${project.version}"
-        ghPublishTask.targetCommitish.get() == project.extensions.grgit.branch.current.name as String
         ghPublishTask.prerelease.get() == (project.properties['release.stage'] != 'final')
+    }
+
+    def "configures github release notes task"() {
+        given: "project with plugins plugin applied"
+        project.plugins.apply(PLUGIN_NAME)
+        project.evaluate()
+
+        and: "switch current branch"
+        getGit().checkout(branch: 'test_branch', createBranch: true, startPoint: getGit().resolve.toRevisionString(getGit().branch.current().fullName))
+
+        when: "evaluating github release notes task"
+        def releaseNotes = project.tasks.getByName(PrivatePluginsPlugin.RELEASE_NOTES_TASK_NAME) as GenerateReleaseNotes
+
+        then: "github publish task should be configured"
+        releaseNotes.branch.get() == 'test_branch'
     }
 
     def "will force groovy modules to local groovy version"() {


### PR DESCRIPTION
## Description

The github publish did not set the target commitish. This is important since we let github create the tag. Without this property github will generate the tag based on the main/default branch which may yield incorrect information.

resolves #89 

## Changes

* ![FIX] missing `targetCommitish` property for github publish

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"