### PR TITLE
Add snyk monitoring [ATLAS-557]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ withCredentials([usernamePassword(credentialsId: 'github_integration', passwordV
                  usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
                  usernamePassword(credentialsId: 'github_integration_3', passwordVariable: 'githubPassword3', usernameVariable: 'githubUser3'),
                  string(credentialsId: 'atlas_plugins_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                 string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
     def testEnvironment = [
         'macos':
         [

--- a/build.gradle
+++ b/build.gradle
@@ -20,20 +20,22 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-github:2.+'
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-github:[2.1,3['
         classpath 'com.gradle.publish:plugin-publish-plugin:0.14.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3)'
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[0.1, 0.2)'
-        classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:[0.1.1,2)'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3['
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[1.1,2['
+        classpath 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
+        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2['
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
-        classpath 'com.wooga.gradle:gradle-commons:[1,2)'
+        classpath 'com.wooga.gradle:gradle-commons:[1,2['
+        classpath 'org.apache.maven:maven-artifact:[3,4['
     }
-    configurations.all {
-        resolutionStrategy {
-            force 'org.ajoberstar.grgit:grgit-core:4.1.1'
-        }
-    }
+}
+
+plugins {
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 apply plugin: new GroovyScriptEngine(
@@ -79,21 +81,25 @@ github {
     repositoryName = "wooga/atlas-plugins"
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
-    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:2.+'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:[2.1,3['
     implementation 'com.gradle.publish:plugin-publish-plugin:0.14.0'
-    implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3)'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[0.1, 0.2)'
-    implementation 'org.ajoberstar.grgit:grgit-gradle:4.1.1'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2)'
+    implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[1.1,2['
+    implementation 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
+    implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2['
     implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
+    implementation 'org.apache.maven:maven-artifact:[3,4['
     testImplementation('com.netflix.nebula:nebula-test:[8,9)') {
         version {
             strictly '8.1.0'
         }
     }
-    testImplementation('junit:junit:[4,5)')
-    testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.1.2'
-    testImplementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5)'
+    testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.3.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PluginsPluginIntegrationSpec.groovy
@@ -45,6 +45,8 @@ class PluginsPluginIntegrationSpec extends IntegrationSpec {
         repo.createRelease("0.0.1", "v0.0.1")
     }
     def setup() {
+        environmentVariables.set("GITHUB_LOGIN", repo.userName)
+        environmentVariables.set("GITHUB_PASSWORD", repo.token)
         def remote = "origin"
         git = Grgit.init(dir: projectDir)
         git.remote.add(name: remote, url: repo.httpTransportUrl)

--- a/src/integrationTest/groovy/wooga/gradle/plugins/PrivatePluginsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/plugins/PrivatePluginsPluginIntegrationSpec.groovy
@@ -47,6 +47,8 @@ class PrivatePluginsPluginIntegrationSpec extends LocalPluginsPluginIntegrationS
     }
 
     def setup() {
+        environmentVariables.set("GITHUB_LOGIN", repo.userName)
+        environmentVariables.set("GITHUB_PASSWORD", repo.token)
         def remote = "origin"
         git = Grgit.init(dir: projectDir)
         git.remote.add(name: remote, url: repo.httpTransportUrl)

--- a/src/main/groovy/wooga/gradle/plugins/LocalPluginsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/plugins/LocalPluginsPlugin.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskContainer
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.gradle.api.tasks.javadoc.Groovydoc
 import org.gradle.api.tasks.testing.Test
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -86,8 +87,8 @@ class LocalPluginsPlugin implements Plugin<Project> {
         JavaPluginConvention javaConvention = project.getConvention().getPlugins().get("java") as JavaPluginConvention
         DependencyHandler dependencies = project.getDependencies();
         dependencies.add("api", dependencies.gradleApi())
-        dependencies.add("implementation", 'commons-io:commons-io:[2,3)')
-        dependencies.add("testImplementation", 'junit:junit:[4,5)')
+        dependencies.add("implementation", 'commons-io:commons-io:[2.7,3)')
+        dependencies.add("testImplementation", 'junit:junit:[4.13.1,5)')
         dependencies.add("testImplementation", 'org.spockframework:spock-core:1.3-groovy-2.5', {
             exclude module: 'groovy-all'
         })
@@ -227,11 +228,13 @@ class LocalPluginsPlugin implements Plugin<Project> {
     private static void forceGroovyVersion(Project project, String version) {
         project.configurations.all({ Configuration configuration ->
             configuration.resolutionStrategy({ ResolutionStrategy strategy ->
-                strategy.force("org.codehaus.groovy:groovy-all:${version}")
-                strategy.force("org.codehaus.groovy:groovy-macro:${version}")
-                strategy.force("org.codehaus.groovy:groovy-nio:${version}")
-                strategy.force("org.codehaus.groovy:groovy-sql:${version}")
-                strategy.force("org.codehaus.groovy:groovy-xml:${version}")
+                def localGroovyVersion = new DefaultArtifactVersion(GroovySystem.getVersion())
+                def localGroovy = localGroovyVersion >= new DefaultArtifactVersion("2.5.14") ? GroovySystem.getVersion() : "2.5.14"
+                strategy.force("org.codehaus.groovy:groovy-all:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-macro:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-nio:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-sql:${localGroovy}")
+                strategy.force("org.codehaus.groovy:groovy-xml:${localGroovy}")
             })
         })
     }

--- a/src/test/groovy/wooga/gradle/plugins/LocalPluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/LocalPluginsPluginSpec.groovy
@@ -3,6 +3,7 @@ package wooga.gradle.plugins
 
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Task
 import org.gradle.api.plugins.GroovyPlugin
@@ -261,7 +262,8 @@ class LocalPluginsPluginSpec extends ProjectSpec {
         project.plugins.apply(PLUGIN_NAME)
 
         expect:
-        def localGroovy = GroovySystem.getVersion()
+        def localGroovyVersion = new DefaultArtifactVersion(GroovySystem.getVersion())
+        def localGroovy = localGroovyVersion >= new DefaultArtifactVersion("2.5.14") ? GroovySystem.getVersion() : "2.5.14"
         project.configurations.every {
             //we turn the list of force modules to string to not test against gradle internals
             def forcedModules = it.resolutionStrategy.forcedModules.toList().collect { it.toString() }
@@ -305,8 +307,8 @@ class LocalPluginsPluginSpec extends ProjectSpec {
 
         where:
         scope                | dependencyString                        | version
-        "implementation"     | "commons-io:commons-io"                 | "[2,3)"
-        "testImplementation" | "junit:junit"                           | "[4,5)"
+        "implementation"     | "commons-io:commons-io"                 | "[2.7,3)"
+        "testImplementation" | "junit:junit"                           | "[4.13.1,5)"
         "testImplementation" | "org.spockframework:spock-core"         | "1.3-groovy-2.5"
         "testImplementation" | "com.netflix.nebula:nebula-test"        | "[8,9)"
         "testImplementation" | "com.github.stefanbirkner:system-rules" | "[1,2)"

--- a/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/plugins/PluginsPluginSpec.groovy
@@ -20,6 +20,7 @@ import com.gradle.publish.PublishPlugin
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.gradle.GrgitPlugin
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Task
 import org.gradle.api.plugins.GroovyPlugin
@@ -329,7 +330,8 @@ class PluginsPluginSpec extends ProjectSpec {
         project.plugins.apply(PLUGIN_NAME)
 
         expect:
-        def localGroovy = GroovySystem.getVersion()
+        def localGroovyVersion = new DefaultArtifactVersion(GroovySystem.getVersion())
+        def localGroovy = localGroovyVersion >= new DefaultArtifactVersion("2.5.14") ? GroovySystem.getVersion() : "2.5.14"
         project.configurations.every {
             //we turn the list of force modules to string to not test against gradle internals
             def forcedModules = it.resolutionStrategy.forcedModules.toList().collect { it.toString() }


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
