### PR TITLE
Update wooga dependencies to new group names and version [ATLAS-730]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,14 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-github:[2.1,3['
+        classpath 'com.wooga.gradle:gradle-commons:[1,2['
+        classpath 'net.wooga.gradle:github:[3,4['
+        classpath 'net.wooga.gradle:github-release-notes:[2,3['
+        classpath 'net.wooga.gradle:version:[2,3['
         classpath 'com.gradle.publish:plugin-publish-plugin:0.14.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3['
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[1.1,2['
         classpath 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
-        classpath 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2['
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
-        classpath 'com.wooga.gradle:gradle-commons:[1,2['
         classpath 'org.apache.maven:maven-artifact:[3,4['
     }
 }
@@ -87,13 +87,13 @@ repositories {
 
 dependencies {
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:[2.1,3['
+    implementation 'net.wooga.gradle:github:[3,4['
+    implementation 'net.wooga.gradle:github-release-notes:[2,3['
+    implementation 'net.wooga.gradle:version:[2,3['
     implementation 'com.gradle.publish:plugin-publish-plugin:0.14.0'
     implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:[2,3['
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[1.1,2['
     implementation 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
     implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1.0.1,2['
     implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
     implementation 'org.apache.maven:maven-artifact:[3,4['
     testImplementation('com.netflix.nebula:nebula-test:[8,9)') {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,5 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-plugins'


### PR DESCRIPTION
## Description

To publish our plugins with the `java-gradle-plugin` plugin means a group change during publish. Since the plugins plugin is using wooga plugins this update process is slighly circular. In normal condition this doesn't really matter but in this case it is needed. So I updated the `github`, `github-release-notes` and the `version` plugin to their new groupname and version

## Changes

* ![UPDATE] `net.wooga.github` plugin groupname and version
* ![UPDATE] `net.wooga.github-release-notes` plugin groupname and version
* ![UPDATE] `net.wooga.version` plugin groupname and version

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"